### PR TITLE
fix: add Yarn 3+ support for GitHub Packages auth

### DIFF
--- a/.github/workflows/module-checks.yaml
+++ b/.github/workflows/module-checks.yaml
@@ -163,11 +163,11 @@ jobs:
         shell: bash
         run: |
           # For npm/yarn classic
-          echo "//npm.pkg.github.com/:_authToken=${{ github.token }}" >> ~/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
 
           # For Yarn Berry (3+)
           if yarn --version 2>/dev/null | grep -qE '^[3-9]\.'; then
-            yarn config set 'npmRegistries["//npm.pkg.github.com"].npmAuthToken' "${{ github.token }}"
+            yarn config set 'npmRegistries["//npm.pkg.github.com"].npmAuthToken' "${{ secrets.GITHUB_TOKEN }}"
           fi
 
       - name: Prepare module

--- a/.github/workflows/module-checks.yaml
+++ b/.github/workflows/module-checks.yaml
@@ -162,10 +162,13 @@ jobs:
       - name: Setup Github packages auth
         shell: bash
         run: |
-          # TODO: support yarn3 with something like (needs a syntax check)
-          # yarn config set npmRegistries.//npm.pkg.github.com.npmAuthToken $NPM_AUTH_TOKEN
-
+          # For npm/yarn classic
           echo "//npm.pkg.github.com/:_authToken=${{ github.token }}" >> ~/.npmrc
+
+          # For Yarn Berry (3+)
+          if yarn --version 2>/dev/null | grep -qE '^[3-9]\.'; then
+            yarn config set 'npmRegistries["//npm.pkg.github.com"].npmAuthToken' "${{ github.token }}"
+          fi
 
       - name: Prepare module
         shell: bash


### PR DESCRIPTION
## Summary
- Adds Yarn Berry (3+) support for GitHub Packages authentication
- Resolves the TODO comment in the existing code
- Keeps backwards compatibility with npm/Yarn Classic

## Problem
Modules using Yarn 4 with dependencies from GitHub Packages fail to build because Yarn Berry ignores `.npmrc` and requires `yarn config set` for registry authentication. Even public GitHub packages require the auth token.

## Solution
Detect Yarn Berry and set `npmRegistries["//npm.pkg.github.com"].npmAuthToken` which applies to all scopes using GitHub Packages.

Tested on companion-module-stagetimerio-api which uses `@stagetimerio/*` packages from GitHub Packages (--> https://github.com/bitfocus/companion-module-stagetimerio-api/actions/runs/20636162847)